### PR TITLE
Links to conferences added

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,18 +3,18 @@ Here is a list of tech conferences I would love to attend or speak at:
 
 | Name | Location | Date |
 | :--- | :--- | :--- |
-| Scala World | Lake District | 31 August 2019 |
+| [Scala World](https://scala.world) | Lake District | 31 August 2019 |
 | Lambadale | London | 21 September 2019 |
-| ViewSource | Amsterdam | 30 Sep - 1 Aug |
-| Mozfest | London | 25-27 Oct |
-| Rustfest | Barcelona | 9-10 Nov |
-| RubyConf | Nashville | 18-20 Nov 2019 |
-| ffconf | Brighton | November 2019 |
-| You Got This | Birmingham | 18 Jan 2020 |
-| FOSDEM | Brussels | Feb 2020 |
-| Afro Tech Fest | London | April 2020 |
-| RailsConf | USA | Spring 2020 |
-| JSConf EU | Berlin | Summer 2020 |
-| Euruko | Helsinki | Summer 2020 |
-| Brighton Ruby | Brighton | Summer 2020 |
-| Lead Dev | London | Summer 2020 |
+| [ViewSource](https://2019.viewsourceconf.org) | Amsterdam | 30 Sep - 1 Aug |
+| [Mozfest](https://www.mozillafestival.org) | London | 25-27 Oct |
+| [Rustfest](https://barcelona.rustfest.eu) | Barcelona | 9-10 Nov |
+| [RubyConf](https://rubyconf.org) | Nashville | 18-20 Nov 2019 |
+| [ffconf](https://ffconf.org) | Brighton | November 2019 |
+| [You Got This](http://yougotthis.io) | Birmingham | 18 Jan 2020 |
+| [FOSDEM](https://fosdem.org/2020/) | Brussels | Feb 2020 |
+| [Afro Tech Fest](https://www.afrotechfest.co.uk) | London | April 2020 |
+| [RailsConf](https://railsconf.com) | USA | Spring 2020 |
+| [JSConf EU](https://2019.jsconf.eu) | Berlin | Summer 2020 |
+| [Euruko](https://euruko2019.org) | Helsinki | Summer 2020 |
+| [Brighton Ruby](https://brightonruby.com) | Brighton | Summer 2020 |
+| [Lead Dev](https://theleaddeveloper.com) | London | Summer 2020 |


### PR DESCRIPTION
I couldn't find a link for one of the conferences.

<img width="615" alt="Screenshot 2019-08-15 08 27 04" src="https://user-images.githubusercontent.com/624760/63079527-7bf05d00-bf36-11e9-93f2-c5663594b1cf.png">